### PR TITLE
The CRM image build carries the file its analyzers are handed

### DIFF
--- a/samples/crm/Dockerfile
+++ b/samples/crm/Dockerfile
@@ -20,7 +20,14 @@ WORKDIR /src
 
 # Restore before the source is copied, so a change to a .cs file does not re-download the world.
 # The glob keeps every project's file at the path the solution expects.
-COPY global.json Directory.Build.props FlowX.slnx .editorconfig ./
+#
+# `SonarLint.xml` is in this list because `Directory.Build.props` declares it as an
+# `AdditionalFiles` for every project. Left out, the file is missing at the path the analyzers are
+# handed, and the build does not degrade to "no Sonar rules" — it fails, with `CS2001` for the
+# missing source file and one `AD0001` per rule that tried to read it. CI never sees this: it
+# checks the whole repository out, so the file is simply there. Only a build whose context is
+# assembled by hand, like this one, can leave it behind.
+COPY global.json Directory.Build.props FlowX.slnx .editorconfig SonarLint.xml ./
 COPY src/ src/
 COPY plugins/ plugins/
 COPY samples/crm/ samples/crm/


### PR DESCRIPTION
`docker compose up --build` cannot succeed on a clean checkout.

## What happens

`Directory.Build.props` declares `SonarLint.xml` as an `AdditionalFiles` for every project. `samples/crm/Dockerfile` assembles its build context by hand — `global.json`, `Directory.Build.props`, `FlowX.slnx`, `.editorconfig` — and does not copy it.

The analyzers are then handed a path that does not exist, and the build does not degrade to “no Sonar rules”. It fails:

```
CSC : error AD0001: Analyzer 'SonarAnalyzer.CSharp.Rules.UseAwaitableMethod' threw an exception of type
'System.InvalidOperationException' with message 'File 'SonarLint.xml' has been added as an AdditionalFile
but could not be read and parsed.'
CSC : error CS2001: Source file '/src/SonarLint.xml' could not be found.
```

…one `AD0001` per rule that tried to read it, and the `CS2001` behind them.

Both the repository root and `samples/crm/README.md` give `docker compose up --build` as the way to run this sample end to end, so this is the first thing a new reader does.

## Why CI never sees it

Every workflow starts from `actions/checkout`, so the file is simply there. A hand-assembled build context is the only place it can go missing, and the repository has exactly one.

## The change

One entry on the `COPY` line, and a comment saying why it belongs there so it does not get tidied away again.

Verified by building the `build` stage to completion against this change.

## Separately

On a clean checkout `dotnet restore` fails **before** reaching this, with exit 155: `global.json` pins SDK `10.0.110` with `rollForward: latestPatch`, and no published `mcr.microsoft.com/dotnet/sdk` image provides a `10.0.1xx` at or above that — `10.0.100-noble` exists and is lower, `10.0.200/301/302-noble` exist and are a different feature band. So `sdk:10.0-noble` can never satisfy it.

That is a policy call rather than a bug, and it is yours to make, so it is not in this PR — I will open an issue with the tag survey unless you would rather it came as a patch.

---
Signed off under the DCO.